### PR TITLE
Add setting in argparse

### DIFF
--- a/nn_play.py
+++ b/nn_play.py
@@ -36,7 +36,7 @@ def multi_scale_search(pivot, screen, range=0.3, num=10):
     return [start_h, start_w, end_h, end_w, score]
 
 class WechatAutoJump(object):
-    def __init__(self, phone, sensitivity, debug, resource_dir):
+    def __init__(self, phone, sensitivity, serverURL, debug, resource_dir):
         self.phone = phone
         self.sensitivity = sensitivity
         self.debug = debug
@@ -44,10 +44,11 @@ class WechatAutoJump(object):
         self.step = 0
         self.ckpt = os.path.join(self.resource_dir, 'train_logs_coarse/best_model.ckpt-13999')
         self.ckpt_fine = os.path.join(self.resource_dir, 'train_log_fine/best_model.ckpt-53999')
+        self.serverURL = serverURL
         self.load_resource()
         if self.phone == 'IOS':
             import wda
-            self.client = wda.Client('http://localhost:8100')
+            self.client = wda.Client(self.serverURL)
             self.s = self.client.session()
         if self.debug:
             if not os.path.exists(self.debug):
@@ -196,6 +197,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--phone', default='Android', choices=['Android', 'IOS'], type=str, help='mobile phone OS')
     parser.add_argument('--sensitivity', default=2.051, type=float, help='constant for press time')
+    parser.add_argument('--serverURL', default='http://localhost:8100', type=str,
+                        help='ServerURL for wda Client')
     parser.add_argument('--resource', default='resource', type=str, help='resource dir')
     parser.add_argument('--debug', default=None, type=str, help='debug mode, specify a directory for storing log files.')
     args = parser.parse_args()

--- a/play.py
+++ b/play.py
@@ -34,7 +34,7 @@ def multi_scale_search(pivot, screen, range=0.3, num=10):
     return [start_h, start_w, end_h, end_w, score]
 
 class WechatAutoJump(object):
-    def __init__(self, phone, sensitivity, debug, resource_dir):
+    def __init__(self, phone, sensitivity, serverURL, debug, resource_dir):
         self.phone = phone
         self.sensitivity = sensitivity
         self.debug = debug
@@ -42,9 +42,10 @@ class WechatAutoJump(object):
         self.bb_size = [300, 300]
         self.step = 0
         self.load_resource()
+        self.serverURL = serverURL
         if self.phone == 'IOS':
             import wda
-            self.client = wda.Client('http://localhost:8100')
+            self.client = wda.Client(self.serverURL)
             self.sess = self.client.session()
         if self.debug:
             if not os.path.exists(self.debug):
@@ -161,10 +162,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--phone', default='Android', choices=['Android', 'IOS'], type=str, help='mobile phone OS')
     parser.add_argument('--sensitivity', default=2.045, type=float, help='constant for press time')
+    parser.add_argument('--serverURL', default='http://localhost:8100', type=str,
+                        help='ServerURL for wda Client')
     parser.add_argument('--resource', default='resource', type=str, help='resource dir')
     parser.add_argument('--debug', default=None, type=str, help='debug mode, specify a directory for storing log files.')
     args = parser.parse_args()
     # print(args)
 
-    AI = WechatAutoJump(args.phone, args.sensitivity, args.debug, args.resource)
+    AI = WechatAutoJump(args.phone, args.sensitivity, args.serverURL, args.debug, args.resource)
     AI.run()


### PR DESCRIPTION
If I don't use iproxy ServerURL is an variable string, and I need to set it by myself like http://10.0.0.1:8100. So I add argument in argparse, so wda instantiation is changed to:
`c = wda.Client(args.serverURL)`
Default value of serverURL is http://localhost:8100. so actually they are work the same way. I hope that is helpful : )
